### PR TITLE
Replace `AppCompatActivity` with `BaseActivity` 

### DIFF
--- a/presentation/src/main/java/com/tdtd/presentation/base/ui/BaseActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/base/ui/BaseActivity.kt
@@ -13,13 +13,6 @@ abstract class BaseActivity<T: ViewDataBinding>(private val layoutId : Int) : Ap
     protected lateinit var binding: T
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        with(window) {
-            requestFeature(Window.FEATURE_CONTENT_TRANSITIONS)
-            // set an slide transition
-            enterTransition = Slide(Gravity.END)
-            exitTransition = Slide(Gravity.START)
-        }
-
         super.onCreate(savedInstanceState)
 
         binding = DataBindingUtil.setContentView(this, layoutId)

--- a/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
@@ -1,10 +1,8 @@
 package com.tdtd.presentation.ui.main
 
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
+import com.tdtd.presentation.base.ui.BaseActivity
 import com.tdtd.presentation.databinding.ActivityMainBinding
 import com.tdtd.presentation.entity.Dummy
 import com.tdtd.presentation.entity.getData
@@ -12,18 +10,13 @@ import com.tdtd.presentation.ui.makeroom.RoomDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
-    private lateinit var binding: ActivityMainBinding
     private val dummyList: List<Dummy> = getData()
     private var mainAdapter = MainAdapter()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
-        binding.lifecycleOwner = this
+    override fun initViews() {
+        super.initViews()
 
         // TEST
         mainAdapter.submitList(dummyList)
@@ -32,6 +25,7 @@ class MainActivity : AppCompatActivity() {
 
         onClickAddImageView()
     }
+
 
     private fun onClickAddImageView() {
         binding.rollingPaperAddImageView.setOnClickListener {


### PR DESCRIPTION
## Summary

* `AppCompatActivity` 를 상속받는 구조에서 `BaseActivity` 를 상속받을 수 있도록 수정합니다.
* 모든 Activity, Fragment에 적용되어야 합니다.

## PR Type

- [ ] 새 기능
- [x] 큰 변경사항
- [ ] 코드스타일 수정
- [ ] 리펙터링
- [ ] 문서내용 변경
- [ ] 그외 기타

