### PR TITLE
Feature/#35 linking pages

### DIFF
--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailAdminActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailAdminActivity.kt
@@ -8,7 +8,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.databinding.ActivityDetailAdminBinding
-import com.tdtd.presentation.ui.rollingpaper.RecordPaperDialogFragment
+import com.tdtd.presentation.ui.recordvoice.RecordVoiceDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -51,7 +51,7 @@ class DetailAdminActivity : AppCompatActivity() {
     }
 
     private fun initVoiceRecordDialogFragment() {
-        val bottomSheet = RecordPaperDialogFragment()
+        val bottomSheet = RecordVoiceDialogFragment()
         bottomSheet.run {
             setStyle(DialogFragment.STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
             show(supportFragmentManager, bottomSheet.tag)

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailAdminActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailAdminActivity.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.databinding.ActivityDetailAdminBinding
+import com.tdtd.presentation.ui.rollingpaper.RecordPaperDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,6 +24,7 @@ class DetailAdminActivity : AppCompatActivity() {
         setContentView(R.layout.activity_detail_admin)
 
         initView()
+        onClickWriteButton()
         onClickFavoritesButton()
     }
 
@@ -38,6 +41,20 @@ class DetailAdminActivity : AppCompatActivity() {
     private fun onClickFavoritesButton() {
         binding.favoritesButton.setOnClickListener {
             binding.favoritesButton.isSelected = !binding.favoritesButton.isSelected
+        }
+    }
+
+    private fun onClickWriteButton() {
+        binding.writeButton.setOnClickListener {
+            initVoiceRecordDialogFragment()
+        }
+    }
+
+    private fun initVoiceRecordDialogFragment() {
+        val bottomSheet = RecordPaperDialogFragment()
+        bottomSheet.run {
+            setStyle(DialogFragment.STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
+            show(supportFragmentManager, bottomSheet.tag)
         }
     }
 }

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailAdminActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailAdminActivity.kt
@@ -3,36 +3,41 @@ package com.tdtd.presentation.ui.detail
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.FrameLayout
-import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
+import androidx.databinding.DataBindingUtil
 import com.tdtd.presentation.R
-import com.tdtd.presentation.databinding.ActivityMainBinding
+import com.tdtd.presentation.databinding.ActivityDetailAdminBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class DetailAdminActivity : AppCompatActivity() {
 
-    private lateinit var toolbar: Toolbar
-    private lateinit var actionBar: ActionBar
-    private lateinit var view: View
-    private lateinit var frameLayout: FrameLayout
     private lateinit var inflater: LayoutInflater
+    private lateinit var view: View
+
+    private lateinit var binding: ActivityDetailAdminBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_detail_admin)
 
+        initView()
+        onClickFavoritesButton()
+    }
+
+    private fun initView() {
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_detail_admin)
+        binding.lifecycleOwner = this
+
         inflater = getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        frameLayout = findViewById<View>(R.id.detailAdminFrameLayout) as FrameLayout
 
-        view = inflater.inflate(R.layout.layout_detail_admin, frameLayout, false)
-        frameLayout.addView(view)
+        view = inflater.inflate(R.layout.layout_detail_admin, binding.detailAdminFrameLayout, false)
+        binding.detailAdminFrameLayout.addView(view)
+    }
 
-        toolbar = findViewById(R.id.app_toolbar)
-        setSupportActionBar(toolbar)
-        actionBar = supportActionBar!!
-        actionBar.setDisplayShowCustomEnabled(true)
+    private fun onClickFavoritesButton() {
+        binding.favoritesButton.setOnClickListener {
+            binding.favoritesButton.isSelected = !binding.favoritesButton.isSelected
+        }
     }
 }

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
@@ -1,9 +1,9 @@
 package com.tdtd.presentation.ui.detail
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
@@ -64,7 +64,9 @@ class DetailUserActivity : AppCompatActivity() {
     private fun onClickLeaveRoomButton() {
         binding.leaveRoomButton.setOnClickListener {
             val dialog = LeaveRoomDialog.getInstance(submitButtonClicked = {
-                Toast.makeText(applicationContext, "submit!", Toast.LENGTH_SHORT).show()
+                intent.putExtra("isLeaveRoom", true)
+                setResult(Activity.RESULT_OK, intent)
+                finish()
             })
             dialog.show(supportFragmentManager, dialog.tag)
         }

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.databinding.ActivityDetailUserBinding
 import com.tdtd.presentation.ui.dialog.LeaveRoomDialog
-import com.tdtd.presentation.ui.rollingpaper.RecordPaperDialogFragment
+import com.tdtd.presentation.ui.writetext.WriteTextDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -54,13 +54,13 @@ class DetailUserActivity : AppCompatActivity() {
     }
 
     private fun initVoiceRecordDialogFragment() {
-        val bottomSheet = RecordPaperDialogFragment()
+        val bottomSheet = WriteTextDialogFragment()
         bottomSheet.run {
             setStyle(DialogFragment.STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
             show(supportFragmentManager, bottomSheet.tag)
         }
     }
-    
+
     private fun onClickLeaveRoomButton() {
         binding.leaveRoomButton.setOnClickListener {
             val dialog = LeaveRoomDialog.getInstance(submitButtonClicked = {

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.databinding.ActivityDetailUserBinding
+import com.tdtd.presentation.ui.rollingpaper.RecordPaperDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,6 +24,7 @@ class DetailUserActivity : AppCompatActivity() {
         setContentView(R.layout.activity_detail_user)
 
         initView()
+        onClickWriteButton()
         onClickFavoritesButton()
     }
 
@@ -38,6 +41,20 @@ class DetailUserActivity : AppCompatActivity() {
     private fun onClickFavoritesButton() {
         binding.favoritesButton.setOnClickListener {
             binding.favoritesButton.isSelected = !binding.favoritesButton.isSelected
+        }
+    }
+
+    private fun onClickWriteButton() {
+        binding.writeButton.setOnClickListener {
+            initVoiceRecordDialogFragment()
+        }
+    }
+
+    private fun initVoiceRecordDialogFragment() {
+        val bottomSheet = RecordPaperDialogFragment()
+        bottomSheet.run {
+            setStyle(DialogFragment.STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
+            show(supportFragmentManager, bottomSheet.tag)
         }
     }
 }

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
@@ -3,11 +3,13 @@ package com.tdtd.presentation.ui.detail
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.databinding.ActivityDetailUserBinding
+import com.tdtd.presentation.ui.dialog.LeaveRoomDialog
 import com.tdtd.presentation.ui.rollingpaper.RecordPaperDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -26,6 +28,7 @@ class DetailUserActivity : AppCompatActivity() {
         initView()
         onClickWriteButton()
         onClickFavoritesButton()
+        onClickLeaveRoomButton()
     }
 
     private fun initView() {
@@ -55,6 +58,15 @@ class DetailUserActivity : AppCompatActivity() {
         bottomSheet.run {
             setStyle(DialogFragment.STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
             show(supportFragmentManager, bottomSheet.tag)
+        }
+    }
+    
+    private fun onClickLeaveRoomButton() {
+        binding.leaveRoomButton.setOnClickListener {
+            val dialog = LeaveRoomDialog.getInstance(submitButtonClicked = {
+                Toast.makeText(applicationContext, "submit!", Toast.LENGTH_SHORT).show()
+            })
+            dialog.show(supportFragmentManager, dialog.tag)
         }
     }
 }

--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailUserActivity.kt
@@ -1,35 +1,43 @@
 package com.tdtd.presentation.ui.detail
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.FrameLayout
-import androidx.appcompat.app.ActionBar
-import androidx.appcompat.widget.Toolbar
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
 import com.tdtd.presentation.R
+import com.tdtd.presentation.databinding.ActivityDetailUserBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DetailUserActivity : AppCompatActivity() {
 
-    private lateinit var toolbar: Toolbar
-    private lateinit var actionBar: ActionBar
-    private lateinit var view: View
-    private lateinit var frameLayout: FrameLayout
     private lateinit var inflater: LayoutInflater
+    private lateinit var view: View
+
+    private lateinit var binding: ActivityDetailUserBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_detail_user)
 
+        initView()
+        onClickFavoritesButton()
+    }
+
+    private fun initView() {
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_detail_user)
+        binding.lifecycleOwner = this
+
         inflater = getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        frameLayout = findViewById<View>(R.id.detailUserFrameLayout) as FrameLayout
 
-        view = inflater.inflate(R.layout.layout_detail_user, frameLayout, false)
-        frameLayout.addView(view)
+        view = inflater.inflate(R.layout.layout_detail_user, binding.detailUserFrameLayout, false)
+        binding.detailUserFrameLayout.addView(view)
+    }
 
-        toolbar = findViewById(R.id.app_toolbar)
-        setSupportActionBar(toolbar)
-        actionBar = supportActionBar!!
-        actionBar.setDisplayShowCustomEnabled(true)
+    private fun onClickFavoritesButton() {
+        binding.favoritesButton.setOnClickListener {
+            binding.favoritesButton.isSelected = !binding.favoritesButton.isSelected
+        }
     }
 }

--- a/presentation/src/main/java/com/tdtd/presentation/ui/dialog/LeaveRoomDialog.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/dialog/LeaveRoomDialog.kt
@@ -1,0 +1,47 @@
+package com.tdtd.presentation.ui.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.tdtd.presentation.R
+import kotlinx.android.synthetic.main.dialog_leave_room.view.*
+
+class LeaveRoomDialog() : DialogFragment(),
+        View.OnClickListener {
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.dialog_leave_room, container)
+
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        view.apply {
+            submitButton.setOnClickListener {
+                submitButtonClicked(true)
+                dismiss()
+            }
+            cancelButton.setOnClickListener {
+                dismiss()
+            }
+        }
+        return view
+    }
+
+    companion object {
+        lateinit var submitButtonClicked: (Boolean) -> Unit
+        fun getInstance(submitButtonClicked: (Boolean) -> Unit): LeaveRoomDialog {
+            this.submitButtonClicked = submitButtonClicked
+            return LeaveRoomDialog()
+        }
+    }
+
+    override fun onClick(p0: View?) {
+        dismiss()
+    }
+}

--- a/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
@@ -2,6 +2,7 @@ package com.tdtd.presentation.ui.main
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
@@ -11,6 +12,7 @@ import com.tdtd.presentation.databinding.ActivityMainBinding
 import com.tdtd.presentation.entity.Dummy
 import com.tdtd.presentation.entity.getData
 import com.tdtd.presentation.ui.detail.DetailAdminActivity
+import com.tdtd.presentation.ui.detail.DetailUserActivity
 import com.tdtd.presentation.ui.makeroom.RoomDialogFragment
 import com.tdtd.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,7 +22,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
     private val dummyList: List<Dummy> = getData()
     private var mainAdapter = MainAdapter() { position ->
-        startActivity(Intent(this, DetailAdminActivity::class.java))
+        if (position == 0) {
+            startActivity(Intent(this, DetailAdminActivity::class.java))
+        } else {
+            startActivity(Intent(this, DetailUserActivity::class.java))
+        }
     }
 
     override fun initViews() {

--- a/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
@@ -1,11 +1,16 @@
 package com.tdtd.presentation.ui.main
 
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.base.ui.BaseActivity
 import com.tdtd.presentation.databinding.ActivityMainBinding
 import com.tdtd.presentation.entity.Dummy
 import com.tdtd.presentation.entity.getData
+import com.tdtd.presentation.ui.detail.DetailAdminActivity
 import com.tdtd.presentation.ui.makeroom.RoomDialogFragment
 import com.tdtd.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -14,7 +19,9 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
     private val dummyList: List<Dummy> = getData()
-    private var mainAdapter = MainAdapter()
+    private var mainAdapter = MainAdapter() { position ->
+        startActivity(Intent(this, DetailAdminActivity::class.java))
+    }
 
     override fun initViews() {
         super.initViews()

--- a/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/main/MainActivity.kt
@@ -1,10 +1,10 @@
 package com.tdtd.presentation.ui.main
 
+import android.app.Activity
 import android.content.Intent
-import android.os.Bundle
-import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
-import androidx.databinding.DataBindingUtil
+import android.view.View
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.DialogFragment
 import com.tdtd.presentation.R
 import com.tdtd.presentation.base.ui.BaseActivity
@@ -21,11 +21,21 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
     private val dummyList: List<Dummy> = getData()
+
+    val startActivityForResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val isLeaveRoom = result.data?.getBooleanExtra("isLeaveRoom", false)
+            if (isLeaveRoom == true) {
+                this@MainActivity.showToast(getString(R.string.toast_leave_room_success), View(applicationContext))
+            }
+        }
+    }
+
     private var mainAdapter = MainAdapter() { position ->
         if (position == 0) {
-            startActivity(Intent(this, DetailAdminActivity::class.java))
+            startDetailAdminActivity()
         } else {
-            startActivity(Intent(this, DetailUserActivity::class.java))
+            startDetailUserActivity()
         }
     }
 
@@ -40,6 +50,15 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         onClickAddImageView()
     }
 
+    private fun startDetailAdminActivity() {
+        val intent = Intent(this, DetailAdminActivity::class.java)
+        startActivityForResult.launch(intent)
+    }
+
+    private fun startDetailUserActivity() {
+        val intent = Intent(this, DetailUserActivity::class.java)
+        startActivityForResult.launch(intent)
+    }
 
     private fun onClickAddImageView() {
         binding.rollingPaperAddImageView.setOnClickListener {
@@ -47,7 +66,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         }
 
         binding.settingButton.setOnClickListener {
-             this@MainActivity.showToast("테스트입니다!", it)
+            this@MainActivity.showToast("테스트입니다!", it)
         }
     }
 

--- a/presentation/src/main/java/com/tdtd/presentation/ui/main/MainAdapter.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/main/MainAdapter.kt
@@ -2,15 +2,18 @@ package com.tdtd.presentation.ui.main
 
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.tdtd.presentation.BR
 import com.tdtd.presentation.databinding.RowMainUserRoomItemBinding
 import com.tdtd.presentation.entity.Dummy
-import com.tdtd.presentation.BR
 
-class MainAdapter() : ListAdapter<Dummy, MainAdapter.MainViewHolder>(CategoryDiffCallback()) {
+class MainAdapter(
+        private val onClick: (position: Int) -> Unit
+) : ListAdapter<Dummy, MainAdapter.MainViewHolder>(CategoryDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MainViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -25,11 +28,14 @@ class MainAdapter() : ListAdapter<Dummy, MainAdapter.MainViewHolder>(CategoryDif
     }
 
     inner class MainViewHolder constructor(val binding: RowMainUserRoomItemBinding) :
-        RecyclerView.ViewHolder(binding.root) {
+            RecyclerView.ViewHolder(binding.root) {
 
         fun bind(data: Dummy) {
             Log.e("df", data.toString())
             binding.setVariable(BR.dummy, data)
+            binding.container.setOnClickListener {
+                onClick(adapterPosition)
+            }
         }
     }
 }

--- a/presentation/src/main/res/drawable/button_selector_favorites.xml
+++ b/presentation/src/main/res/drawable/button_selector_favorites.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/ic_favorites_on_32"
+        android:state_selected="true" />
+    <item
+        android:drawable="@drawable/ic_favorites_off_32" />
+</selector>

--- a/presentation/src/main/res/layout/activity_detail_admin.xml
+++ b/presentation/src/main/res/layout/activity_detail_admin.xml
@@ -81,7 +81,7 @@
                 android:layout_marginRight="16dp"
                 android:layout_marginBottom="16dp"
                 android:background="@drawable/fab_shape_beige2_radius18"
-                android:src="@drawable/ic_favorites_off_32"
+                android:src="@drawable/button_selector_favorites"
                 app:layout_constraintBottom_toTopOf="@+id/writeButton"
                 app:layout_constraintEnd_toEndOf="parent" />
 

--- a/presentation/src/main/res/layout/activity_detail_user.xml
+++ b/presentation/src/main/res/layout/activity_detail_user.xml
@@ -81,7 +81,7 @@
                 android:layout_marginRight="16dp"
                 android:layout_marginBottom="16dp"
                 android:background="@drawable/fab_shape_beige2_radius18"
-                android:src="@drawable/ic_favorites_off_32"
+                android:src="@drawable/button_selector_favorites"
                 app:layout_constraintBottom_toTopOf="@+id/writeButton"
                 app:layout_constraintEnd_toEndOf="parent" />
 

--- a/presentation/src/main/res/layout/activity_detail_user.xml
+++ b/presentation/src/main/res/layout/activity_detail_user.xml
@@ -58,7 +58,7 @@
                         app:layout_constraintTop_toTopOf="parent" />
 
                     <androidx.appcompat.widget.AppCompatImageView
-                        android:id="@+id/moreButton"
+                        android:id="@+id/leaveRoomButton"
                         android:layout_width="40dp"
                         android:layout_height="40dp"
                         android:background="@drawable/background_beige3_stroke1_beige4_radius16"

--- a/presentation/src/main/res/layout/row_main_user_room_item.xml
+++ b/presentation/src/main/res/layout/row_main_user_room_item.xml
@@ -11,6 +11,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="112dp"
         android:layout_margin="8dp"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -54,4 +54,7 @@
     <string name="dialog_report_reply_content">정말 답장을 신고하시겠어요?🚨</string>
     <string name="dialog_report_reply_button_submit">신고할래요</string>
     <string name="dialog_report_reply_button_cancel">안 할래요!</string>
+
+    <!-- Toast -->
+    <string name="toast_leave_room_success">방에서 탈출했어요!</string>
 </resources>


### PR DESCRIPTION
## Summary

- 즐겨찾기 버튼 클릭시 노란 별로 변경하는 기능을 추가합니다.
- `DetailAdminActivity` 에서 작성하기 버튼 클릭시 Record 바텀시트를 출력합니다.
- 용이한 테스팅을 위해, 메인 페이지 방의 position에 따라 Activity를 분기하여 출력합니다. (`0`: `DetailAdminActivity`, 이외: `DetailUserActivity`)


## Screen Shot

<p>
	<img src="https://user-images.githubusercontent.com/13195817/110365753-c42b1f00-8088-11eb-80e9-bce99a5ca999.jpg", width="300" />
	<img src="https://user-images.githubusercontent.com/13195817/110365905-f0df3680-8088-11eb-9512-7989c7b4ea2e.jpg", width="300" />
	<img src="https://user-images.githubusercontent.com/13195817/110365758-c5f4e280-8088-11eb-9b58-8298950f4eef.jpg", width="300" />
</p>



## PR Type

- [x] 새 기능
- [ ] 큰 변경사항
- [ ] 코드스타일 수정
- [ ] 리펙터링
- [ ] 문서내용 변경
- [ ] 그외 기타

