### PR TITLE
fix: Toast에 그림자를 추가합니다.

### DIFF
--- a/presentation/src/main/res/layout/layout_toast.xml
+++ b/presentation/src/main/res/layout/layout_toast.xml
@@ -1,27 +1,38 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:background="@drawable/background_character1_radius24"
-    android:clipToPadding="false"
-    android:elevation="8dp"
-    android:paddingStart="16dp"
-    android:paddingTop="6dp"
-    android:paddingEnd="16dp"
-    android:paddingBottom="6dp">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/toastTextView"
+    <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/text.16dp.regular.white"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="남기고 싶은 말을 써주세요 !" />
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="12dp"
+            android:background="@drawable/background_character1_radius24"
+            android:elevation="8dp"
+            android:paddingStart="16dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="8dp">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/toastTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/text.16dp.regular.white"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="남기고 싶은 말을 써주세요 !" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary

- 그림자가 표시되지 않던 Toast를 수정합니다.
- 디자인 가이드에 따라 paddingTop/paddionBottom 값을 수정합니다.(8dp)


## Screen Shot
<p>
	<img src="https://user-images.githubusercontent.com/13195817/114295403-ff819900-9adf-11eb-918b-65aff65836b7.jpeg", width="300" />
</p>


## PR Type

- [x] 새 기능
- [ ] 큰 변경사항
- [ ] 코드스타일 수정
- [ ] 리펙터링
- [ ] 문서내용 변경
- [ ] 그외 기타

