### PR TITLE
Fix/bottomsheet height

### DIFF
--- a/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailSharedBottomSheetFragment.kt
+++ b/presentation/src/main/java/com/tdtd/presentation/ui/detail/DetailSharedBottomSheetFragment.kt
@@ -34,7 +34,6 @@ class DetailSharedBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initParentHeight(requireActivity(), view, 420)
         initDate()
         onClickCancelButton()
         onClickSharedLink()

--- a/presentation/src/main/res/layout/fragment_detail_admin.xml
+++ b/presentation/src/main/res/layout/fragment_detail_admin.xml
@@ -104,27 +104,28 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="64dp"
-                android:layout_marginTop="216dp"
                 android:layout_marginEnd="64dp"
+                android:layout_marginBottom="24dp"
                 android:gravity="center"
                 android:text="@string/detail_admin_content_shared_link"
                 android:textAppearance="@style/text.20dp.regular.grayscale4"
+                app:layout_constraintBottom_toTopOf="@+id/sharedLinkButton"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/sharedLinkButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
                 android:background="@drawable/button_shape_grayscale1_radius12"
                 android:gravity="center"
                 android:text="@string/detail_admin_button_shared_link"
                 android:textAppearance="@style/text.20dp.regular.white"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/sharedLinkTextView" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/favoritesButton"


### PR DESCRIPTION
## Summary

- [x] Bottom Sheet의 height가 잘못 세팅된 부분을 수정합니다.
- [x] Detail Admin Page가 비어 있는 상태의 text와 button 위치를 조정합니다.


## Screen Shot

### Before
<p>
	<img src="https://user-images.githubusercontent.com/13195817/117175452-d5cf3f80-ae09-11eb-9f62-f4c8b2b4aac4.jpg", width="300" /><img src="https://user-images.githubusercontent.com/13195817/117175457-d8319980-ae09-11eb-94c5-8dcc7c360743.jpg", width="300" />
</p>

### After
<p>
	<img src="https://user-images.githubusercontent.com/13195817/117175454-d7006c80-ae09-11eb-87e5-4bc1f5645b62.jpg", width="300" /><img src="https://user-images.githubusercontent.com/13195817/117175459-d8ca3000-ae09-11eb-8623-a54240149a12.jpg", width="300" />
</p>

## PR Type

- [ ] 새 기능
- [ ] 큰 변경사항
- [ ] 코드스타일 수정
- [ ] 리펙터링
- [ ] 문서내용 변경
- [x] 그외 기타

